### PR TITLE
Add Loader and Action for Remix Crash

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -8,6 +8,7 @@ import { PassThrough } from "stream";
 import "dotenv/config";
 
 let locales: string[];
+const NOT_LOCALIZED = ["_remix-crash"];
 
 export default async function handleRequest(
   request: Request,
@@ -35,7 +36,9 @@ export default async function handleRequest(
     locales = data._site.locales;
   }
 
-  if (!locales.some((l) => url.pathname.startsWith(`/${l}`))) {
+  if (
+    !locales.concat(NOT_LOCALIZED).some((l) => url.pathname.startsWith(`/${l}`))
+  ) {
     // checks if the URL doesn't contain a valid language
     const preferredLanguage = await localeCookie.parse(
       request.headers.get("Cookie")

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -69,10 +69,11 @@ export default async function handleRequest(
   );
 
   responseHeaders.set("Content-Type", "text/html");
-  responseHeaders.set(
-    "Set-Cookie",
-    await localeCookie.serialize(url.pathname.split("/")[1])
-  );
+  if (/\/\w{2}\//.test(url.pathname))
+    responseHeaders.set(
+      "Set-Cookie",
+      await localeCookie.serialize(url.pathname.split("/")[1])
+    );
 
   // @ts-ignore It is fine.
   return new Response(stream, {

--- a/app/routes/_remix-crash.ts
+++ b/app/routes/_remix-crash.ts
@@ -1,0 +1,1 @@
+export { loader, action } from "remix-crash";


### PR DESCRIPTION
Hello,

I saw you added remix-crash (thanks to github) to your project and I'm pretty excited that people are starting using it in their remix projects.

I noticed that you are missing the `loader` & `action` required for `remix-crash` to read the source map (cf. [docs](https://github.com/xstevenyung/remix-crash#in-approutes_remix-crashjsx)).

I took the liberty to add them for you.

Hope Remix Crash works for you and that you enjoy it, if you encounter any issue, feel free to open issues on `remix-crash` repository

Cheers !